### PR TITLE
Replace result table with dropdown for IOL selection

### DIFF
--- a/flask_ophthalmology_form_app.py
+++ b/flask_ophthalmology_form_app.py
@@ -136,6 +136,22 @@ def api_prefill():
         print(f"Error in /api/prefill: {e}")
         return jsonify({"ok": False, "error": str(e)}), 500
 
+
+@app.route('/api/select_iol', methods=['POST'])
+def api_select_iol():
+    try:
+        payload = request.get_json(silent=True) or {}
+        iol_power = payload.get('iol_power')
+        sphere = payload.get('sphere')
+
+        # 目前仅记录选择，具体业务逻辑待定
+        app.logger.info('接收到 IOL 度数选择: iol_power=%s, sphere=%s', iol_power, sphere)
+
+        return jsonify({"ok": True, "message": "已记录选择"})
+    except Exception as exc:
+        app.logger.exception('处理 IOL 度数选择时出错')
+        return jsonify({"ok": False, "error": str(exc)}), 500
+
 if __name__ == '__main__':
     os.makedirs('static/html', exist_ok=True)
     app.run(host='0.0.0.0', port=5000, debug=True)

--- a/static/html/template.html
+++ b/static/html/template.html
@@ -124,7 +124,7 @@
         document.body.removeChild(tempLink);
         URL.revokeObjectURL(url);
       });
-    });
+    })();
   </script>
   <script>
   (function() {

--- a/static/html/template.html
+++ b/static/html/template.html
@@ -61,23 +61,19 @@
       <h1>计算结果</h1>
       {% if result is not none %}
         {% if result and result|length > 0 %}
-        <table>
-          <thead>
-            <tr>
-              <th>IOL度数</th>
-              <th>1m-矫正球镜度数 (D)</th>
-            </tr>
-          </thead>
-          <tbody>
+        <div class="field">
+          <label for="resultDropdown">可选 IOL 度数</label>
+          <select id="resultDropdown" style="border:1px solid #e5e7eb;border-radius:10px;padding:10px 12px;font-size:14px;outline:none;">
+            <option value="" disabled selected>请选择一个度数</option>
             {% for row in result %}
-            <tr>
-              <td>{{ row[0] }}</td>
-              <td>{{ row[1] }}</td>
-            </tr>
+            <option value="{{ row[0] }}" data-iol="{{ row[0] }}" data-sphere="{{ row[1] }}">
+              IOL度数：{{ row[0] }}（1m-矫正球镜度数：{{ row[1] }}）
+            </option>
             {% endfor %}
-          </tbody>
-        </table>
-        <div class="result-actions">
+          </select>
+        </div>
+        <div class="result-actions" style="display:flex;gap:12px;flex-wrap:wrap;">
+          <button type="button" class="secondary" id="selectDegreeBtn">选择度数</button>
           <button type="button" class="secondary" id="downloadCsv">导出为 CSV</button>
         </div>
         {% else %}
@@ -180,5 +176,47 @@
     }
   })();
 </script>
+  <script>
+    (function() {
+      const dropdown = document.getElementById('resultDropdown');
+      const selectBtn = document.getElementById('selectDegreeBtn');
+
+      if (!dropdown || !selectBtn) {
+        return;
+      }
+
+      selectBtn.addEventListener('click', async function() {
+        const option = dropdown.selectedOptions[0];
+        if (!option || !option.dataset.iol) {
+          alert('请选择一个度数');
+          return;
+        }
+
+        const payload = {
+          iol_power: option.dataset.iol ? parseFloat(option.dataset.iol) : null,
+          sphere: option.dataset.sphere ? parseFloat(option.dataset.sphere) : null,
+        };
+
+        try {
+          const response = await fetch('/api/select_iol', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(payload),
+          });
+
+          const data = await response.json();
+          if (!data.ok) {
+            throw new Error(data.error || '未知错误');
+          }
+
+          alert(data.message || '已提交选择');
+        } catch (error) {
+          alert('提交失败：' + error.message);
+        }
+      });
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the calculation results table with a dropdown that lists IOL options and provides a selection button
- send the chosen IOL value back to the server via a new frontend script for future processing
- add a backend API endpoint that records the selected IOL power and associated sphere value

## Testing
- python -m compileall flask_ophthalmology_form_app.py static/html/template.html

------
https://chatgpt.com/codex/tasks/task_e_68e3d6880554832198659a1a86ad241d